### PR TITLE
Changed icon name due to version change in heroicons

### DIFF
--- a/files/FilamentResource.vemtl
+++ b/files/FilamentResource.vemtl
@@ -60,7 +60,7 @@ class <$ crudModelName $>Resource extends Resource
 {
     protected static ?string $model = <$ crudModelName $>::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-collection';
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
     protected static ?string $recordTitleAttribute = '<$ this.crud.model.getLabelFieldName() $>';
 
@@ -87,7 +87,7 @@ class <$ crudModelName $>Resource extends Resource
                                 <% } %>
                                 <###>
                                 <% if(input.field.nullable) { %>
-                                ->nullable() 
+                                ->nullable()
                                 <% } else { %>
                                 ->required()
                                 <% } %>


### PR DESCRIPTION
The old o-collection name no longer exists so you get an svg not found error. Changed it to the new heroicon-o-rectangle-stack that replaces that in the new version of heroicons.